### PR TITLE
Added Capibility to test the bluetooth communication with a socket based java application.

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="VcsDirectoryMappings">
-    <mapping directory="" vcs="" />
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
   </component>
 </project>

--- a/app/src/main/java/com/haloproject/bluetooth/AndroidBlue.java
+++ b/app/src/main/java/com/haloproject/bluetooth/AndroidBlue.java
@@ -15,11 +15,7 @@ import android.os.Looper;
 import android.util.Log;
 import android.widget.ArrayAdapter;
 
-import com.haloproject.bluetooth.InputHandlers.BeagleAutoOffSwitch;
-import com.haloproject.bluetooth.InputHandlers.BeagleAutoSwitch;
-import com.haloproject.bluetooth.InputHandlers.BeagleSwitch;
-import com.haloproject.bluetooth.OutputHandlers.BeagleDoubleOutput;
-import com.haloproject.bluetooth.OutputHandlers.BeagleIntegerOutput;
+import com.haloproject.bluetooth.BluetoothInterfaces.JSONCommunicationDevice;
 import com.haloproject.projectspartanv2.SoundMessageHandler;
 import com.haloproject.projectspartanv2.Warning;
 
@@ -28,15 +24,15 @@ import org.json.JSONObject;
 
 import java.io.IOException;
 import java.io.OutputStream;
+import java.io.Serializable;
 import java.lang.reflect.Method;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * Created by Adam Brykajlo on 18/02/15.
  */
-public class AndroidBlue {
+public class AndroidBlue implements JSONCommunicationDevice, Serializable {
     private final int REQUEST_ENABLE_BT = 42;
 
     private List<Warning> mWarnings;
@@ -62,7 +58,9 @@ public class AndroidBlue {
     private SoundPool soundPool;
     private int volume;
 
-    private AndroidBlue(SoundPool soundPool, int volume) {
+    private AndroidBlue(SoundPool soundPool, int volume, Context context) {
+        this.mContext = context;
+
         this.isSoundOn = false;
         this.soundPool = soundPool;
         this.volume = volume;
@@ -100,14 +98,10 @@ public class AndroidBlue {
         isSoundOn = true;
     }
 
-    public static void setContext(Context context) {
-        mContext = context;
-    }
-
-    public static AndroidBlue getInstance(SoundPool soundPool,int volume) {
+    public static AndroidBlue getInstance(SoundPool soundPool, int volume) {
         if (mContext != null) {
             if (mAndroidBlue == null) {
-                mAndroidBlue = new AndroidBlue(soundPool,volume);
+                mAndroidBlue = new AndroidBlue(soundPool,volume, mContext);
             }
             return mAndroidBlue;
         }
@@ -124,6 +118,10 @@ public class AndroidBlue {
         } else {
             return null;
         }
+    }
+
+    public static void setContext(Context context) {
+        mContext = context;
     }
 
     public boolean isEnabled() {

--- a/app/src/main/java/com/haloproject/bluetooth/BluetoothInterfaces/JSONCommunicationDevice.java
+++ b/app/src/main/java/com/haloproject/bluetooth/BluetoothInterfaces/JSONCommunicationDevice.java
@@ -1,0 +1,15 @@
+package com.haloproject.bluetooth.BluetoothInterfaces;
+
+import org.json.JSONObject;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+/**
+ * Created by Tyler on 7/25/2015.
+ */
+public interface JSONCommunicationDevice {
+
+    JSONObject getJSON();
+    OutputStream getOutputStream() throws IOException;
+}

--- a/app/src/main/java/com/haloproject/bluetooth/DeviceHandlerCollection.java
+++ b/app/src/main/java/com/haloproject/bluetooth/DeviceHandlerCollection.java
@@ -2,16 +2,19 @@ package com.haloproject.bluetooth;
 
 import android.bluetooth.BluetoothClass;
 
+import com.haloproject.bluetooth.BluetoothInterfaces.JSONCommunicationDevice;
 import com.haloproject.bluetooth.InputHandlers.BeagleAutoOffSwitch;
 import com.haloproject.bluetooth.InputHandlers.BeagleAutoSwitch;
 import com.haloproject.bluetooth.InputHandlers.BeagleSwitch;
 import com.haloproject.bluetooth.OutputHandlers.BeagleDoubleOutput;
 import com.haloproject.bluetooth.OutputHandlers.BeagleIntegerOutput;
 
+import java.io.Serializable;
+
 /**
  * Created by Tyler on 7/6/2015.
  */
-public class DeviceHandlerCollection {
+public class DeviceHandlerCollection implements Serializable {
 
     private static DeviceHandlerCollection deviceHandlerCollection;
 
@@ -41,31 +44,31 @@ public class DeviceHandlerCollection {
     public final BeagleDoubleOutput armpitsTemperature;
     public final BeagleIntegerOutput heartRate;
 
-    private DeviceHandlerCollection() {
-        headTemperature = new BeagleDoubleOutput("head temperature");
-        crotchTemperature = new BeagleDoubleOutput("crotch temperature");
-        armpitsTemperature = new BeagleDoubleOutput("armpits temperature");
-        waterTemperature = new BeagleDoubleOutput("water temperature");
+    private DeviceHandlerCollection(JSONCommunicationDevice communicationDevice) {
+        headTemperature = new BeagleDoubleOutput("head temperature", communicationDevice);
+        crotchTemperature = new BeagleDoubleOutput("crotch temperature", communicationDevice);
+        armpitsTemperature = new BeagleDoubleOutput("armpits temperature", communicationDevice);
+        waterTemperature = new BeagleDoubleOutput("water temperature", communicationDevice);
 
-        flowRate = new BeagleIntegerOutput("flow rate");
-        heartRate = new BeagleIntegerOutput("heart rate");
-        battery2AH = new BeagleIntegerOutput("2 AH battery");
-        battery8AH = new BeagleIntegerOutput("8 AH battery");
-        batteryAndroid = new BeagleIntegerOutput("phone battery");
-        batteryGlass = new BeagleIntegerOutput("hud battery");
+        flowRate = new BeagleIntegerOutput("flow rate", communicationDevice);
+        heartRate = new BeagleIntegerOutput("heart rate", communicationDevice);
+        battery2AH = new BeagleIntegerOutput("2 AH battery", communicationDevice);
+        battery8AH = new BeagleIntegerOutput("8 AH battery", communicationDevice);
+        batteryAndroid = new BeagleIntegerOutput("phone battery", communicationDevice);
+        batteryGlass = new BeagleIntegerOutput("hud battery", communicationDevice);
 
 
-        redHeadLight = new BeagleSwitch("head lights red");
-        whiteHeadLight = new BeagleSwitch("head lights white");
-        peltier = new BeagleAutoOffSwitch("peltier");
-        waterPump = new BeagleAutoOffSwitch("water pump");
-        headFans = new BeagleSwitch("head fans");
-        mainLights = new BeagleAutoSwitch("lights");
+        redHeadLight = new BeagleSwitch("head lights red", communicationDevice);
+        whiteHeadLight = new BeagleSwitch("head lights white", communicationDevice);
+        peltier = new BeagleAutoOffSwitch("peltier", communicationDevice);
+        waterPump = new BeagleAutoOffSwitch("water pump", communicationDevice);
+        headFans = new BeagleSwitch("head fans", communicationDevice);
+        mainLights = new BeagleAutoSwitch("lights", communicationDevice);
     }
 
-    public static DeviceHandlerCollection getInstance() {
+    public static DeviceHandlerCollection getInstance(JSONCommunicationDevice communicationDevice) {
         if(deviceHandlerCollection == null) {
-            deviceHandlerCollection = new DeviceHandlerCollection();
+            deviceHandlerCollection = new DeviceHandlerCollection(communicationDevice);
         }
 
         return deviceHandlerCollection;

--- a/app/src/main/java/com/haloproject/bluetooth/InputHandlers/BeagleAutoOffSwitch.java
+++ b/app/src/main/java/com/haloproject/bluetooth/InputHandlers/BeagleAutoOffSwitch.java
@@ -1,12 +1,15 @@
 package com.haloproject.bluetooth.InputHandlers;
 
+import com.haloproject.bluetooth.AndroidBlue;
+import com.haloproject.bluetooth.BluetoothInterfaces.JSONCommunicationDevice;
+
 /**
  * Created by Tyler on 7/5/2015.
  * turn switched auto or off
  */
 public class BeagleAutoOffSwitch extends BeagleInputHandler {
-    public BeagleAutoOffSwitch(String location) {
-        super(location);
+    public BeagleAutoOffSwitch(String location, JSONCommunicationDevice communicationDevice) {
+        super(location, communicationDevice);
     }
 
     public void auto() {

--- a/app/src/main/java/com/haloproject/bluetooth/InputHandlers/BeagleAutoSwitch.java
+++ b/app/src/main/java/com/haloproject/bluetooth/InputHandlers/BeagleAutoSwitch.java
@@ -7,7 +7,7 @@ import com.haloproject.bluetooth.BluetoothInterfaces.JSONCommunicationDevice;
  * Created by Tyler on 7/5/2015.
  * turns things on or off or auto
  */
-public class BeagleAutoSwitch extends BeagleInputHandler {
+public class BeagleAutoSwitch extends BeagleInputHandler { //TODO: should probably extend BeagleSwitch (BeagleSwitch has on/off isOn/isOff functions)
     public BeagleAutoSwitch(String location, JSONCommunicationDevice communicationDevice) {
         super(location, communicationDevice);
     }

--- a/app/src/main/java/com/haloproject/bluetooth/InputHandlers/BeagleAutoSwitch.java
+++ b/app/src/main/java/com/haloproject/bluetooth/InputHandlers/BeagleAutoSwitch.java
@@ -1,12 +1,15 @@
 package com.haloproject.bluetooth.InputHandlers;
 
+import com.haloproject.bluetooth.AndroidBlue;
+import com.haloproject.bluetooth.BluetoothInterfaces.JSONCommunicationDevice;
+
 /**
  * Created by Tyler on 7/5/2015.
  * turns things on or off or auto
  */
 public class BeagleAutoSwitch extends BeagleInputHandler {
-    public BeagleAutoSwitch(String location) {
-        super(location);
+    public BeagleAutoSwitch(String location, JSONCommunicationDevice communicationDevice) {
+        super(location, communicationDevice);
     }
 
     public void auto() {

--- a/app/src/main/java/com/haloproject/bluetooth/InputHandlers/BeagleInputHandler.java
+++ b/app/src/main/java/com/haloproject/bluetooth/InputHandlers/BeagleInputHandler.java
@@ -1,5 +1,7 @@
 package com.haloproject.bluetooth.InputHandlers;
 
+import android.util.Log;
+
 import com.haloproject.bluetooth.AndroidBlue;
 import com.haloproject.bluetooth.BluetoothInterfaces.JSONCommunicationDevice;
 
@@ -23,7 +25,8 @@ public abstract class BeagleInputHandler {
             switchObject.put(location, state);
             mCommunicationDevice.getOutputStream().write(switchObject.toString().getBytes());
         } catch (Exception e) {
-
+            //may want to throw exception to UI layer for better handling.
+            Log.d("OutputStreamInformation", "outputStream is not set yet"); //should have a better key and error message.
         }
     }
 

--- a/app/src/main/java/com/haloproject/bluetooth/InputHandlers/BeagleInputHandler.java
+++ b/app/src/main/java/com/haloproject/bluetooth/InputHandlers/BeagleInputHandler.java
@@ -1,6 +1,7 @@
 package com.haloproject.bluetooth.InputHandlers;
 
 import com.haloproject.bluetooth.AndroidBlue;
+import com.haloproject.bluetooth.BluetoothInterfaces.JSONCommunicationDevice;
 
 import org.json.JSONObject;
 
@@ -9,18 +10,18 @@ import org.json.JSONObject;
  */
 public abstract class BeagleInputHandler {
     protected String location;
-    protected AndroidBlue androidBlue;
+    protected JSONCommunicationDevice mCommunicationDevice;
 
-    public BeagleInputHandler(String location) {
+    public BeagleInputHandler(String location, JSONCommunicationDevice communicationDevice) {
         this.location = location;
-        this.androidBlue = AndroidBlue.getInstance();
+        mCommunicationDevice = communicationDevice;
     }
 
     protected void setState(String state) {
         try {
             JSONObject switchObject = new JSONObject();
             switchObject.put(location, state);
-            androidBlue.getOutputStream().write(switchObject.toString().getBytes());
+            mCommunicationDevice.getOutputStream().write(switchObject.toString().getBytes());
         } catch (Exception e) {
 
         }
@@ -28,7 +29,7 @@ public abstract class BeagleInputHandler {
 
     protected boolean isStateSet(String state) {
         try {
-            return androidBlue.getJSON().getString(location).equals(state);
+            return mCommunicationDevice.getJSON().getString(location).equals(state);
         } catch (Exception e) {
             return false;
         }

--- a/app/src/main/java/com/haloproject/bluetooth/InputHandlers/BeagleSwitch.java
+++ b/app/src/main/java/com/haloproject/bluetooth/InputHandlers/BeagleSwitch.java
@@ -1,12 +1,15 @@
 package com.haloproject.bluetooth.InputHandlers;
 
+import com.haloproject.bluetooth.AndroidBlue;
+import com.haloproject.bluetooth.BluetoothInterfaces.JSONCommunicationDevice;
+
 /**
  * Created by Tyler on 7/5/2015.
  * used for turning things on or off on the beaglebone
  */
 public class BeagleSwitch extends BeagleInputHandler {
-    public BeagleSwitch(String location) {
-        super(location);
+    public BeagleSwitch(String location, JSONCommunicationDevice communicationDevice) {
+        super(location, communicationDevice);
     }
 
     public void on() {

--- a/app/src/main/java/com/haloproject/bluetooth/OutputHandlers/BeagleDoubleOutput.java
+++ b/app/src/main/java/com/haloproject/bluetooth/OutputHandlers/BeagleDoubleOutput.java
@@ -1,6 +1,7 @@
 package com.haloproject.bluetooth.OutputHandlers;
 
 import com.haloproject.bluetooth.AndroidBlue;
+import com.haloproject.bluetooth.BluetoothInterfaces.JSONCommunicationDevice;
 
 import org.json.JSONObject;
 
@@ -9,16 +10,16 @@ import org.json.JSONObject;
  */
 public class BeagleDoubleOutput {
     private String location;
-    private AndroidBlue mAndroidBlue;
+    private JSONCommunicationDevice mCommunicationDevice;
 
-    public BeagleDoubleOutput(String location) {
+    public BeagleDoubleOutput(String location, JSONCommunicationDevice communicationDevice) {
         this.location = location;
-        mAndroidBlue = AndroidBlue.getInstance();
+        mCommunicationDevice = communicationDevice;
     }
 
     public double getValue() {
         try {
-            return mAndroidBlue.getJSON().getDouble(location); //get double could accept and integer because double is bigger than an integer. thus this code will work for both ints and doubles
+            return mCommunicationDevice.getJSON().getDouble(location); //get double could accept and integer because double is bigger than an integer. thus this code will work for both ints and doubles
         } catch (Exception e) {
             return -1000.0;
         }

--- a/app/src/main/java/com/haloproject/bluetooth/OutputHandlers/BeagleIntegerOutput.java
+++ b/app/src/main/java/com/haloproject/bluetooth/OutputHandlers/BeagleIntegerOutput.java
@@ -1,6 +1,7 @@
 package com.haloproject.bluetooth.OutputHandlers;
 
 import com.haloproject.bluetooth.AndroidBlue;
+import com.haloproject.bluetooth.BluetoothInterfaces.JSONCommunicationDevice;
 
 /**
  * Created by Tyler on 7/5/2015.
@@ -8,16 +9,16 @@ import com.haloproject.bluetooth.AndroidBlue;
 public class BeagleIntegerOutput {
 
     private String location;
-    private AndroidBlue mAndroidBlue;
+    private JSONCommunicationDevice mCommunicationDevice;
 
-    public BeagleIntegerOutput(String location) {
+    public BeagleIntegerOutput(String location, JSONCommunicationDevice communicationDevice) {
         this.location = location;
-        mAndroidBlue = AndroidBlue.getInstance();
+        mCommunicationDevice = communicationDevice;
     }
 
     public int getValue() {
         try {
-            return mAndroidBlue.getJSON().getInt(location); //get double could accept and integer because double is bigger than an integer. thus this code will work for both ints and doubles
+            return mCommunicationDevice.getJSON().getInt(location); //get double could accept and integer because double is bigger than an integer. thus this code will work for both ints and doubles
         } catch (Exception e) {
             return -1;
         }

--- a/app/src/main/java/com/haloproject/projectspartanv2/Fragments/BatteryFragment.java
+++ b/app/src/main/java/com/haloproject/projectspartanv2/Fragments/BatteryFragment.java
@@ -1,6 +1,5 @@
 package com.haloproject.projectspartanv2.Fragments;
 
-import android.bluetooth.BluetoothClass;
 import android.os.Bundle;
 import android.support.v4.app.Fragment;
 import android.view.LayoutInflater;
@@ -27,11 +26,28 @@ public class BatteryFragment extends Fragment {
     private AndroidBlue mAndroidBlue;
     private DeviceHandlerCollection mDeviceHandlerCollection;
 
+    private static final String ANDROID_BLUE_KEY = "androidBlue";
+    private static final String DEVICE_HANDLER_COLLECTION_KEY = "deviceHandlerCollection";
+
+    public static BatteryFragment newInstance(AndroidBlue mAndroidBlue, DeviceHandlerCollection mDeviceHandlerCollection) {
+        BatteryFragment fragment = new BatteryFragment();
+
+        final Bundle args = new Bundle();
+
+        args.putSerializable(ANDROID_BLUE_KEY, mAndroidBlue);
+        args.putSerializable(DEVICE_HANDLER_COLLECTION_KEY, mDeviceHandlerCollection);
+
+        fragment.setArguments(args);
+
+        return fragment;
+    }
+
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         mTopBar = MainActivity.mTopBar;
-        mAndroidBlue = AndroidBlue.getInstance();
-        mDeviceHandlerCollection = DeviceHandlerCollection.getInstance();
+
+        mAndroidBlue = (AndroidBlue) getArguments().getSerializable(ANDROID_BLUE_KEY);
+        mDeviceHandlerCollection = (DeviceHandlerCollection) getArguments().getSerializable(DEVICE_HANDLER_COLLECTION_KEY);
 
 
         mTopBar.setMenuName("Batteries");

--- a/app/src/main/java/com/haloproject/projectspartanv2/Fragments/CoolingFragment.java
+++ b/app/src/main/java/com/haloproject/projectspartanv2/Fragments/CoolingFragment.java
@@ -21,16 +21,33 @@ public class CoolingFragment extends Fragment {
     private TempWheel waterTemp;
     private TextView flowPump;
 
-    private AndroidBlue mAndroidBlue;
     private TopBar mTopBar;
+    private AndroidBlue mAndroidBlue;
     private DeviceHandlerCollection mDeviceHandlerCollection;
+
+    private static final String ANDROID_BLUE_KEY = "androidBlue";
+    private static final String DEVICE_HANDLER_COLLECTION_KEY = "deviceHandlerCollection";
+
+    public static CoolingFragment newInstance(AndroidBlue mAndroidBlue, DeviceHandlerCollection mDeviceHandlerCollection) {
+        CoolingFragment fragment = new CoolingFragment();
+
+        final Bundle args = new Bundle();
+
+        args.putSerializable(ANDROID_BLUE_KEY, mAndroidBlue);
+        args.putSerializable(DEVICE_HANDLER_COLLECTION_KEY, mDeviceHandlerCollection);
+
+        fragment.setArguments(args);
+
+        return fragment;
+    }
 
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container,
                              Bundle savedInstanceState) {
         mTopBar = MainActivity.mTopBar;
-        mAndroidBlue = AndroidBlue.getInstance();
-        mDeviceHandlerCollection = DeviceHandlerCollection.getInstance();
+
+        mAndroidBlue = (AndroidBlue) getArguments().getSerializable(ANDROID_BLUE_KEY);
+        mDeviceHandlerCollection = (DeviceHandlerCollection) getArguments().getSerializable(DEVICE_HANDLER_COLLECTION_KEY);
 
 
         mTopBar.setMenuName("Cooling");

--- a/app/src/main/java/com/haloproject/projectspartanv2/Fragments/CoolingFragment.java
+++ b/app/src/main/java/com/haloproject/projectspartanv2/Fragments/CoolingFragment.java
@@ -1,10 +1,13 @@
 package com.haloproject.projectspartanv2.Fragments;
 
 import android.os.Bundle;
+import android.provider.MediaStore;
 import android.support.v4.app.Fragment;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.RadioButton;
 import android.widget.TextView;
 
 import com.haloproject.bluetooth.AndroidBlue;
@@ -20,6 +23,15 @@ import com.haloproject.projectspartanv2.view.TopBar;
 public class CoolingFragment extends Fragment {
     private TempWheel waterTemp;
     private TextView flowPump;
+
+    private RadioButton peltierAuto;
+    private RadioButton peltierOff;
+
+    private RadioButton headFansOn;
+    private RadioButton headFansOff;
+
+    private RadioButton waterPumpAuto;
+    private RadioButton waterPumpOff;
 
     private TopBar mTopBar;
     private AndroidBlue mAndroidBlue;
@@ -51,55 +63,81 @@ public class CoolingFragment extends Fragment {
 
 
         mTopBar.setMenuName("Cooling");
+
+
+        // load and store views from xml file
         View view = inflater.inflate(R.layout.fragment_cooling, container, false);
         waterTemp = (TempWheel) view.findViewById(R.id.waterTemp);
         flowPump = (TextView) view.findViewById(R.id.flowPump);
 
-        //set onclick listeners
-        view.findViewById(R.id.peltierauto).setOnClickListener(new View.OnClickListener() {
+        peltierAuto = (RadioButton) view.findViewById(R.id.peltierauto);
+        peltierOff = (RadioButton) view.findViewById(R.id.peltieroff);
+
+        headFansOn = (RadioButton) view.findViewById(R.id.headfanson);
+        headFansOff = (RadioButton) view.findViewById(R.id.headfansoff);
+
+        waterPumpAuto = (RadioButton) view.findViewById(R.id.waterpumpauto);
+        waterPumpOff = (RadioButton) view.findViewById(R.id.waterpumpoff);
+
+        // set onclick listeners
+        peltierAuto.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
                 mDeviceHandlerCollection.peltier.auto();
             }
         });
-        view.findViewById(R.id.peltieroff).setOnClickListener(new View.OnClickListener() {
+        peltierOff.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
                 mDeviceHandlerCollection.peltier.off();
             }
         });
-        view.findViewById(R.id.headfanson).setOnClickListener(new View.OnClickListener() {
+
+        headFansOn.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
                 mDeviceHandlerCollection.headFans.on();
             }
         });
-        view.findViewById(R.id.headfansoff).setOnClickListener(new View.OnClickListener() {
+        headFansOff.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
                 mDeviceHandlerCollection.headFans.off();
             }
         });
-        view.findViewById(R.id.waterpumpauto).setOnClickListener(new View.OnClickListener() {
+
+        waterPumpAuto.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
                 mDeviceHandlerCollection.waterPump.auto();
             }
         });
-        view.findViewById(R.id.waterpumpoff).setOnClickListener(new View.OnClickListener() {
+        waterPumpOff.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
                 mDeviceHandlerCollection.waterPump.off();
             }
         });
+
         mAndroidBlue.setOnReceive(new Runnable() {
             @Override
             public void run() {
                 waterTemp.setTemp(mDeviceHandlerCollection.waterTemperature.getValue());
-                int flow = mDeviceHandlerCollection.flowRate.getValue();
-                String newFlow = String.format("%d", flow);
 
+
+                int flow = mDeviceHandlerCollection.flowRate.getValue();
+
+                String newFlow = String.format("%d", flow);
                 flowPump.setText(newFlow);
+
+                peltierAuto.setChecked(mDeviceHandlerCollection.peltier.isAuto());
+                peltierOff.setChecked(mDeviceHandlerCollection.peltier.isOff());
+
+                headFansOn.setChecked(mDeviceHandlerCollection.headFans.isOn());
+                headFansOff.setChecked(mDeviceHandlerCollection.headFans.isOff());
+
+                waterPumpAuto.setChecked(mDeviceHandlerCollection.waterPump.isAuto());
+                waterPumpOff.setChecked(mDeviceHandlerCollection.waterPump.isOff());
             }
         });
         return view;

--- a/app/src/main/java/com/haloproject/projectspartanv2/Fragments/LightingFragment.java
+++ b/app/src/main/java/com/haloproject/projectspartanv2/Fragments/LightingFragment.java
@@ -42,7 +42,7 @@ public class LightingFragment extends Fragment {
         mDeviceHandlerCollection =(DeviceHandlerCollection) getArguments().getSerializable(DEVICE_HANDLER_COLLECTION_KEY);
 
 
-//        mTopBar.setMenuName("Lighting");
+        mTopBar.setMenuName("Lighting");
         View view = inflater.inflate(R.layout.fragment_lighting, container, false);
         view.findViewById(R.id.mainlightson).setOnClickListener(new View.OnClickListener() {
             @Override

--- a/app/src/main/java/com/haloproject/projectspartanv2/Fragments/LightingFragment.java
+++ b/app/src/main/java/com/haloproject/projectspartanv2/Fragments/LightingFragment.java
@@ -19,7 +19,19 @@ public class LightingFragment extends Fragment {
     private TopBar mTopBar;
     private DeviceHandlerCollection mDeviceHandlerCollection;
 
+    private static final String DEVICE_HANDLER_COLLECTION_KEY = "deviceHandlerCollection";
 
+    public static LightingFragment newInstance(DeviceHandlerCollection mDeviceHandlerCollection) {
+        LightingFragment fragment = new LightingFragment();
+
+        final Bundle args = new Bundle();
+
+        args.putSerializable(DEVICE_HANDLER_COLLECTION_KEY, mDeviceHandlerCollection);
+
+        fragment.setArguments(args);
+
+        return fragment;
+    }
 
 
     @Override
@@ -27,7 +39,7 @@ public class LightingFragment extends Fragment {
                              Bundle savedInstanceState) {
         // Inflate the layout for this fragment
         mTopBar = MainActivity.mTopBar;
-        mDeviceHandlerCollection = DeviceHandlerCollection.getInstance();
+        mDeviceHandlerCollection =(DeviceHandlerCollection) getArguments().getSerializable(DEVICE_HANDLER_COLLECTION_KEY);
 
 
 //        mTopBar.setMenuName("Lighting");

--- a/app/src/main/java/com/haloproject/projectspartanv2/Fragments/MainFragment.java
+++ b/app/src/main/java/com/haloproject/projectspartanv2/Fragments/MainFragment.java
@@ -1,0 +1,62 @@
+package com.haloproject.projectspartanv2.Fragments;
+
+import android.os.Bundle;
+import android.support.v4.app.Fragment;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.HorizontalScrollView;
+import android.widget.LinearLayout;
+
+import com.haloproject.bluetooth.AndroidBlue;
+import com.haloproject.projectspartanv2.MainActivity;
+import com.haloproject.projectspartanv2.R;
+import com.haloproject.projectspartanv2.view.TopBar;
+
+/**
+ * Created by Tyler on 8/2/2015.
+ */
+public class MainFragment extends Fragment {
+    private LinearLayout mainMenu;
+    private HorizontalScrollView scrollView;
+
+    private AndroidBlue mAndroidBlue;
+    private TopBar mTopBar;
+
+    private static final String ANDROID_BLUE_KEY = "androidBlue";
+
+    public static MainFragment newInstance(AndroidBlue mAndroidBlue) {
+        MainFragment fragment = new MainFragment();
+
+        final Bundle args = new Bundle();
+
+        args.putSerializable(ANDROID_BLUE_KEY, mAndroidBlue);
+
+        fragment.setArguments(args);
+
+        return fragment;
+    }
+
+
+    @Override
+    public View onCreateView(LayoutInflater inflater, ViewGroup container,
+                             Bundle savedInstanceState) {
+        mAndroidBlue = (AndroidBlue) getArguments().getSerializable(ANDROID_BLUE_KEY);
+        mTopBar = MainActivity.mTopBar;
+
+        MainActivity.setCurrentFragmentToMainMenu();
+
+        mTopBar.setMenuName("Main Menu");
+        // Inflate the layout for this fragment
+        View view = inflater.inflate(R.layout.fragment_main, container, false);
+        mainMenu = (LinearLayout) view.findViewById(R.id.mainmenu);
+        scrollView = (HorizontalScrollView) view.findViewById(R.id.scrollview);
+        return view;
+    }
+
+    @Override
+    public void onDestroyView() {
+        super.onDestroyView();
+        mAndroidBlue.changeOnReceive();
+    }
+}

--- a/app/src/main/java/com/haloproject/projectspartanv2/Fragments/RadarFragment.java
+++ b/app/src/main/java/com/haloproject/projectspartanv2/Fragments/RadarFragment.java
@@ -16,6 +16,10 @@ import com.haloproject.projectspartanv2.view.TopBar;
 public class RadarFragment extends Fragment {
     private TopBar mTopBar;
 
+    public static RadarFragment newInstance() {
+        return new RadarFragment();
+    }
+
 
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container,

--- a/app/src/main/java/com/haloproject/projectspartanv2/Fragments/SettingsFragment.java
+++ b/app/src/main/java/com/haloproject/projectspartanv2/Fragments/SettingsFragment.java
@@ -24,10 +24,25 @@ public class SettingsFragment extends Fragment {
     private TopBar mTopBar;
     private AndroidBlue mAndroidBlue;
 
+    private static final String ANDROID_BLUE_KEY = "androidBlue";
+    private static final String DEVICE_HANDLER_COLLECTION_KEY = "deviceHandlerCollection";
+
+    public static SettingsFragment newInstance(AndroidBlue mAndroidBlue) {
+        SettingsFragment fragment = new SettingsFragment();
+
+        final Bundle args = new Bundle();
+
+        args.putSerializable(ANDROID_BLUE_KEY, mAndroidBlue);
+
+        fragment.setArguments(args);
+
+        return fragment;
+    }
+
     @Override
     public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
         mTopBar = MainActivity.mTopBar;
-        mAndroidBlue = AndroidBlue.getInstance();
+        mAndroidBlue = (AndroidBlue) getArguments().getSerializable(ANDROID_BLUE_KEY);
 
 
         mTopBar.setMenuName("Settings");

--- a/app/src/main/java/com/haloproject/projectspartanv2/Fragments/VitalsFragment.java
+++ b/app/src/main/java/com/haloproject/projectspartanv2/Fragments/VitalsFragment.java
@@ -28,12 +28,28 @@ public class VitalsFragment extends Fragment {
     private AndroidBlue mAndroidBlue;
     private DeviceHandlerCollection mDeviceHandlerCollection;
 
+    private static final String ANDROID_BLUE_KEY = "androidBlue";
+    private static final String DEVICE_HANDLER_COLLECTION_KEY = "deviceHandlerCollection";
+
+    public static VitalsFragment newInstance(AndroidBlue mAndroidBlue, DeviceHandlerCollection mDeviceHandlerCollection) {
+        VitalsFragment fragment = new VitalsFragment();
+
+        final Bundle args = new Bundle();
+
+        args.putSerializable(ANDROID_BLUE_KEY, mAndroidBlue);
+        args.putSerializable(DEVICE_HANDLER_COLLECTION_KEY, mDeviceHandlerCollection);
+
+        fragment.setArguments(args);
+
+        return fragment;
+    }
 
     @Override
     public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
         mTopBar = MainActivity.mTopBar;
-        mAndroidBlue = AndroidBlue.getInstance();
-        mDeviceHandlerCollection = DeviceHandlerCollection.getInstance();
+
+        mAndroidBlue = (AndroidBlue) getArguments().getSerializable(ANDROID_BLUE_KEY);
+        mDeviceHandlerCollection = (DeviceHandlerCollection) getArguments().getSerializable(DEVICE_HANDLER_COLLECTION_KEY);
 
 
         mTopBar.setMenuName("Vitals");

--- a/app/src/main/java/com/haloproject/projectspartanv2/MainActivity.java
+++ b/app/src/main/java/com/haloproject/projectspartanv2/MainActivity.java
@@ -28,6 +28,7 @@ import android.widget.ListView;
 import android.widget.TextView;
 
 import com.haloproject.bluetooth.AndroidBlue;
+import com.haloproject.bluetooth.DeviceHandlerCollection;
 import com.haloproject.projectspartanv2.Fragments.BatteryFragment;
 import com.haloproject.projectspartanv2.Fragments.CoolingFragment;
 import com.haloproject.projectspartanv2.Fragments.LightingFragment;
@@ -218,19 +219,19 @@ public class MainActivity extends ActionBarActivity implements SensorEventListen
     private static Fragment swipeFragment(int fragment) {
         switch (fragment) {
             case 0:
-                return new VitalsFragment();
+                return VitalsFragment.newInstance(mAndroidBlue, DeviceHandlerCollection.getInstance(mAndroidBlue));
             case 1:
-                return new CoolingFragment();
+                return CoolingFragment.newInstance(mAndroidBlue, DeviceHandlerCollection.getInstance(mAndroidBlue));
             case 2:
-                return new LightingFragment();
+                return LightingFragment.newInstance(DeviceHandlerCollection.getInstance(mAndroidBlue));
             case 3:
-                return new RadarFragment();
+                return RadarFragment.newInstance();
             case 4:
-                return new BatteryFragment();
+                return BatteryFragment.newInstance(mAndroidBlue, DeviceHandlerCollection.getInstance(mAndroidBlue));
             case 5:
                 return new WarningsFragment();
             case 6:
-                return new SettingsFragment();
+                return SettingsFragment.newInstance(mAndroidBlue);
             default:
                 return new MainFragment();
         }
@@ -244,14 +245,11 @@ public class MainActivity extends ActionBarActivity implements SensorEventListen
     }
 
     private void toggleVoice(MainButton view) {
-        if(mMicrophoneHandler.isMicOn())
-        {
+        if(mMicrophoneHandler.isMicOn()) {
             mMicrophoneHandler.turnMicOff();
             view.setIcon(getResources().getDrawable(R.drawable.speaker_off_icon));
             view.invalidate();
-        }
-        else
-        {
+        } else {
             mMicrophoneHandler.turnMicOn();
             view.setIcon(getResources().getDrawable(R.drawable.speaker_on_icon));
             view.invalidate();
@@ -259,14 +257,12 @@ public class MainActivity extends ActionBarActivity implements SensorEventListen
     }
 
     private void toggleSounds(MainButton view) {
-        if(mAndroidBlue.isSoundOn())
-        {
+        if(mAndroidBlue.isSoundOn()) {
             mAndroidBlue.turnSoundOff();
             view.setIcon(getResources().getDrawable(R.drawable.music_off_icon));
             view.invalidate();
         }
-        else
-        {
+        else {
             mAndroidBlue.turnSoundOn();
             view.setIcon(getResources().getDrawable(R.drawable.music_on_icon));
             view.invalidate();

--- a/app/src/main/java/com/haloproject/projectspartanv2/MainActivity.java
+++ b/app/src/main/java/com/haloproject/projectspartanv2/MainActivity.java
@@ -64,7 +64,7 @@ public class MainActivity extends ActionBarActivity implements SensorEventListen
 
     @Override
     public void onAccuracyChanged(Sensor sensor, int accuracy) {
-
+        //TODO: why do we have this here.  This appears to be for working with the gyroscope and other hardware functionality
     }
 
     @Override
@@ -146,7 +146,7 @@ public class MainActivity extends ActionBarActivity implements SensorEventListen
             }
         }
         mTopBar = (TopBar) findViewById(R.id.topbar);
-        updateTopBar(mTopBar);
+        updateTopBar();
 
         if (!mAndroidBlue.isEnabled()) {
             mAndroidBlue.enableBluetooth(this);
@@ -346,7 +346,7 @@ public class MainActivity extends ActionBarActivity implements SensorEventListen
         return super.onOptionsItemSelected(item);
     }
 
-    private static void updateTopBar(final TopBar mTopBar) {
+    private static void updateTopBar() {
         if (mAndroidBlue.isConnected()) {
             mTopBar.setBluetooth(true);
         } else {

--- a/app/src/main/java/com/haloproject/projectspartanv2/MainActivity.java
+++ b/app/src/main/java/com/haloproject/projectspartanv2/MainActivity.java
@@ -32,6 +32,7 @@ import com.haloproject.bluetooth.DeviceHandlerCollection;
 import com.haloproject.projectspartanv2.Fragments.BatteryFragment;
 import com.haloproject.projectspartanv2.Fragments.CoolingFragment;
 import com.haloproject.projectspartanv2.Fragments.LightingFragment;
+import com.haloproject.projectspartanv2.Fragments.MainFragment;
 import com.haloproject.projectspartanv2.Fragments.RadarFragment;
 import com.haloproject.projectspartanv2.Fragments.SettingsFragment;
 import com.haloproject.projectspartanv2.Fragments.VitalsFragment;
@@ -113,7 +114,13 @@ public class MainActivity extends ActionBarActivity implements SensorEventListen
         setupAudioServices();
         int volume = getVolume();
 
+        mMicrophoneHandler = MicrophoneHandler.getInstance();
+
+        AndroidBlue.setContext(getApplicationContext());
+        mAndroidBlue = AndroidBlue.getInstance(soundPool, volume);
+
         setContentView(R.layout.activity_main);
+
         //set up wakelock
         params = new WindowManager.LayoutParams();
         params.flags |= WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON;
@@ -121,15 +128,16 @@ public class MainActivity extends ActionBarActivity implements SensorEventListen
         mFragmentManager = getSupportFragmentManager();
         if (savedInstanceState == null) {
             mFragmentManager.beginTransaction()
-                    .add(R.id.container, new MainFragment())
+                    .add(R.id.container, MainFragment.newInstance(mAndroidBlue))
                     .commit();
 
             currentFragment = -1;
         }
 
-        mMicrophoneHandler = MicrophoneHandler.getInstance();
-        AndroidBlue.setContext(getApplicationContext());
-        mAndroidBlue = AndroidBlue.getInstance(soundPool, volume);
+
+
+
+
         mPreferences = getPreferences(MODE_PRIVATE);
         if (mPreferences.contains("bluetooth")) {
             String device = mPreferences.getString("bluetooth", "");
@@ -233,7 +241,7 @@ public class MainActivity extends ActionBarActivity implements SensorEventListen
             case 6:
                 return SettingsFragment.newInstance(mAndroidBlue);
             default:
-                return new MainFragment();
+                return MainFragment.newInstance(mAndroidBlue);
         }
     }
 
@@ -269,6 +277,7 @@ public class MainActivity extends ActionBarActivity implements SensorEventListen
         }
     }
 
+    //TODO: do these need to accept a view?
     public void vitals(View view) {
         currentFragment = 0;
         openCurrentFragment();
@@ -303,6 +312,11 @@ public class MainActivity extends ActionBarActivity implements SensorEventListen
         currentFragment = 6;
         openCurrentFragment();
     }
+
+    public static void setCurrentFragmentToMainMenu() {
+        currentFragment = -1;
+    }
+
     public void voice(View view) {
         toggleVoice((MainButton)view);
     }
@@ -354,29 +368,6 @@ public class MainActivity extends ActionBarActivity implements SensorEventListen
                 mTopBar.setBluetooth(false);
             }
         });
-    }
-
-    public static class MainFragment extends Fragment {
-        private LinearLayout mainMenu;
-        private HorizontalScrollView scrollView;
-
-        @Override
-        public View onCreateView(LayoutInflater inflater, ViewGroup container,
-                                 Bundle savedInstanceState) {
-            currentFragment = -1;
-            mTopBar.setMenuName("Main Menu");
-            // Inflate the layout for this fragment
-            View view = inflater.inflate(R.layout.fragment_main, container, false);
-            mainMenu = (LinearLayout) view.findViewById(R.id.mainmenu);
-            scrollView = (HorizontalScrollView) view.findViewById(R.id.scrollview);
-            return view;
-        }
-
-        @Override
-        public void onDestroyView() {
-            super.onDestroyView();
-            mAndroidBlue.changeOnReceive();
-        }
     }
 
     public static class WarningsFragment extends Fragment {

--- a/app/src/main/java/com/haloproject/projectspartanv2/MainActivity.java
+++ b/app/src/main/java/com/haloproject/projectspartanv2/MainActivity.java
@@ -100,6 +100,7 @@ public class MainActivity extends ActionBarActivity implements SensorEventListen
         getWindow().getDecorView().setSystemUiVisibility(View.SYSTEM_UI_FLAG_HIDE_NAVIGATION
                 | View.SYSTEM_UI_FLAG_IMMERSIVE
                 | View.SYSTEM_UI_FLAG_FULLSCREEN
+                | View.SYSTEM_UI_FLAG_FULLSCREEN
                 | View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY);
         mSensorManager.registerListener(this, mSensor, SensorManager.SENSOR_DELAY_NORMAL);
     }
@@ -127,7 +128,7 @@ public class MainActivity extends ActionBarActivity implements SensorEventListen
 
         mMicrophoneHandler = MicrophoneHandler.getInstance();
         AndroidBlue.setContext(getApplicationContext());
-        mAndroidBlue = AndroidBlue.getInstance(soundPool,volume);
+        mAndroidBlue = AndroidBlue.getInstance(soundPool, volume);
         mPreferences = getPreferences(MODE_PRIVATE);
         if (mPreferences.contains("bluetooth")) {
             String device = mPreferences.getString("bluetooth", "");

--- a/app/src/main/java/com/haloproject/projectspartanv2/SoundMessageHandler.java
+++ b/app/src/main/java/com/haloproject/projectspartanv2/SoundMessageHandler.java
@@ -5,36 +5,33 @@ import android.media.SoundPool;
 import org.json.JSONException;
 import org.json.JSONObject;
 
-public class SoundMessageHandler
-{
-    public static void handleSoundMessage(JSONObject jsonObject, final SoundPool soundPool, final int volume)
-    {
-        if(jsonObject.has("play sound"))
-        {
-            try
-            {
+public class SoundMessageHandler {
+    public static void handleSoundMessage(JSONObject jsonObject, final SoundPool soundPool, final int volume) {
+        if(jsonObject.has("play sound")) {
+            try {
                 final String soundToPlay = jsonObject.getString("play sound");
+
                 new Thread(new Runnable()
                 {
                     @Override
                     public void run()
                     {
-                        if(soundToPlay.equals("lights"))
-                        {
+
+                        if(soundToPlay.equals("lights"))  {
                             soundPool.play(1,volume,volume,1,0,1);
-                        }
-                        else if(soundToPlay.equals("shield_off"))
-                        {
+                        } else if(soundToPlay.equals("shield_off")) {
                             soundPool.play(2,volume,volume,1,0,1);
-                        }
-                        else if(soundToPlay.equals("shield_on"))
-                        {
+                        } else if(soundToPlay.equals("shield_on")) {
                             soundPool.play(3,volume,volume,1,0,1);
                         }
+
                     }
                 }).start();
-            } catch (JSONException e)
-            {}
+
+            } catch (JSONException e) {
+
+
+            }
 
         }
     }


### PR DESCRIPTION
In order to allow for the app to be tested without the BeagleBone I modified the AndroidBlue class to work with a internet based socket.  
To make this work for most of the bluetooth based methods I simply had them return true if testing with the socket.
This difference in control flow, along with the fact that the socket is not started as soon as the app is launched, are the two main differences for socket vs. the old implementation.
Theres probably a better way to do what I did (maybe with inheritance) and we should look into that later.

I also refactored the Fragments to gain all their dependencies through dependency injection rather than directly accessing them. This will improve testibility, specifically in the area of unit testing.

In order to test the new server based testing framework you need to change IS_TESTING_WITH_SOCKET to true, launch the app in the emulator, launch the corresponding app on your computer found here https://github.com/SFU-Embedded-Cosplay/Halo-Suit-Test-Server and then click "Start Discovery" in setting to establish a connection
