### PR TITLE
Send state of charge to beaglebone

### DIFF
--- a/app/src/main/java/com/haloproject/bluetooth/AndroidBlue.java
+++ b/app/src/main/java/com/haloproject/bluetooth/AndroidBlue.java
@@ -272,6 +272,7 @@ public class AndroidBlue implements JSONCommunicationDevice, Serializable {
                     }
 
                     new Thread(new ConnectedRunnable()).start();
+                    new Thread(new BatteryRunnable()).start();
                 } catch (Exception e) {
 
                 }

--- a/app/src/main/java/com/haloproject/projectspartanv2/Fragments/BatteryFragment.java
+++ b/app/src/main/java/com/haloproject/projectspartanv2/Fragments/BatteryFragment.java
@@ -67,6 +67,7 @@ public class BatteryFragment extends Fragment {
         mAndroidBlue.setOnReceive(new Runnable() {
             @Override
             public void run() {
+                android.setBatteryCharge(getBatteryLevel());
                 highAmp.setBatteryCharge(mDeviceHandlerCollection.battery8AH.getValue());
                 lowAmp.setBatteryCharge(mDeviceHandlerCollection.battery2AH.getValue());
                 glass.setBatteryCharge(mDeviceHandlerCollection.batteryGlass.getValue());


### PR DESCRIPTION
This patch updates the phones battery level every time a message is received, while on the battery fragment. Additionally a heartbeat is sent with the phones battery level (between 0-100) every 5 seconds.

This fixes #11 
